### PR TITLE
Exclude Velero backups from the resources traced by ArgoCD

### DIFF
--- a/platform/charts/argocd/templates/argocd-configs/argocd-cm.yaml
+++ b/platform/charts/argocd/templates/argocd-configs/argocd-cm.yaml
@@ -45,3 +45,13 @@ data:
     requestedScopes: {{ .requestedScopes }}
     {{- end }}
   {{- end }}
+  # Until Velero v1.6.0 is released we've to ignore the Backup resource, 
+  # because there is no owner reference between the schedule and the backup.
+  # When the prune is active, or flagged during a sync, ArgoCD will delete the backup without this exclusion
+  resource.exclusions: |
+    - apiGroups:
+      - "velero.io"
+      kinds:
+      - Backup
+      clusters:
+      - "*"


### PR DESCRIPTION
With the current version of Velero if an application deployed with ArgoCD contains a `Schedule` when this creates a `Backup` the application goes directly "Out of Sync".

This is because currently the `Schedule` creates a `Backup` without the owner reference and ArgoCD cannot link the two resources; this means that if the `autoPrune` is active or the `prune` flag is enabled during sync, ArgoCD will delete the backup.

For now, we'll just ignore the `Backup` resources in ArgoCD, anyway this problem is already fixed https://github.com/vmware-tanzu/velero/pull/3127 and when Velero `1.6.0` is released, and we update it, we can remove the `rersource.exclusions` from the configmap.