### PR TITLE
Configure ArgoCD to ignore clientConfig/caBundle on webhooks

### DIFF
--- a/components/argocd/templates/argocd-configs/argocd-cm.yaml
+++ b/components/argocd/templates/argocd-configs/argocd-cm.yaml
@@ -68,3 +68,12 @@ data:
       - Backup
       clusters:
       - "*"
+  resource.customizations: |
+    admissionregistration.k8s.io/MutatingWebhookConfiguration:
+      ignoreDifferences: |
+        jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+    admissionregistration.k8s.io/ValidatingWebhookConfiguration:
+      ignoreDifferences: |
+        jsonPointers:
+        - /webhooks/0/clientConfig/caBundle


### PR DESCRIPTION
We need to ignore the `webhook/*/clientConfig/caBundle` path on the `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` otherwise ArgoCD keeps updating them.

Here we're going to ignore just the first one `webhook/0`, this should cover the majority of the cases. ArgoCD allows us to specify a JSON Path using the [RFC6902 JSON patches](https://tools.ietf.org/html/rfc6902) and does not support the wildcard `*` operator.